### PR TITLE
git diff

### DIFF
--- a/bin/git-cml
+++ b/bin/git-cml
@@ -9,7 +9,7 @@ import json
 import git
 import logging
 
-from git_cml import git_utils
+from git_cml import git_utils, checkpoints
 
 logging.basicConfig(
     level=logging.DEBUG, format="git-cml: [%(asctime)s] %(levelname)s - %(message)s"
@@ -33,16 +33,17 @@ def parse_args():
     return args
 
 
-def iterate_dict_and_subdirs(d, root):
+def iterate_dict_and_dir_leaves(d, root):
     """
-    Generator that recursively iterates through a dictionary and produces (leaf, subdir) tuples where leaf is a dictionary leaf
-    and subdir is the subdirectory below root corresponding to the sequence of keys used to access leaf. Each subdir is created if it does not exist.
+    Generator that iterates through dictionary leaves and produces (param, param_file) tuples where param is a dictionary leaf
+    and param_file is the file below root corresponding to the sequence of keys used to access the dictionary leaf. Each subdirectory
+    between root and param_file is created if it does not exist.
 
     Example
     -------
     d = {'a': {'b': {'c': 10, 'd': 20, 'e': 30}}}
     root = 'rootdir'
-    iterate_dict_and_subdirs(d, root) --> ((10, 'rootdir/a/b/c'), (20, 'rootdir/a/b/d'), (30, 'rootdir/a/b/e'))
+    iterate_dict_and_dir_leaves(d, root) --> ((10, 'rootdir/a/b/c'), (20, 'rootdir/a/b/d'), (30, 'rootdir/a/b/e'))
 
     Parameters
     ----------
@@ -51,14 +52,11 @@ def iterate_dict_and_subdirs(d, root):
     root : str
         path to root directory where directory tree representing `d` is created
     """
-    for k, v in d.items():
-        if isinstance(v, dict):
-            recursive_root = os.path.join(root, k)
-            yield from iterate_dict_and_subdirs(v, recursive_root)
-        else:
-            if not os.path.exists(root):
-                os.makedirs(root)
-            yield (v, os.path.join(root, k))
+    for leaf, keys in checkpoints.iterate_dict_leaves(d):
+        param_file = os.path.join(root, '/'.join(keys))
+        if not os.path.exists(os.path.dirname(param_file)):
+            os.makedirs(os.path.dirname(param_file))
+        yield leaf, param_file
 
 
 def add(args):
@@ -68,8 +66,8 @@ def add(args):
     repo = git_utils.get_git_repo()
     model_path = git_utils.create_git_cml_model_dir(repo, args.file)
 
-    param_dict = git_utils.load_tracked_file(args.file)
-    for (param, param_file) in iterate_dict_and_subdirs(param_dict, model_path):
+    param_dict = checkpoints.JSONCheckpoint.from_file(args.file)
+    for (param, param_file) in iterate_dict_and_dir_leaves(param_dict, model_path):
         git_utils.write_tracked_file(param_file, param)
         git_utils.add_file(param_file, repo)
 

--- a/bin/git-cml
+++ b/bin/git-cml
@@ -21,13 +21,16 @@ def parse_args():
     subparsers = parser.add_subparsers(title="Commands", dest="command")
     subparsers.required = True
 
-    add_parser = subparsers.add_parser("add", help="add command used to stage a model file")
+    add_parser = subparsers.add_parser(
+        "add", help="add command used to stage a model file"
+    )
     add_parser.add_argument("file", help="file being staged")
     add_parser.set_defaults(func=add)
 
-    init_parser = subparsers.add_parser("init", help="init command used to setup a git-cml repo")
+    init_parser = subparsers.add_parser(
+        "init", help="init command used to setup a git-cml repo"
+    )
     init_parser.set_defaults(func=init)
-
 
     args = parser.parse_args()
     return args
@@ -53,7 +56,7 @@ def iterate_dict_and_dir_leaves(d, root):
         path to root directory where directory tree representing `d` is created
     """
     for leaf, keys in checkpoints.iterate_dict_leaves(d):
-        param_file = os.path.join(root, '/'.join(keys))
+        param_file = os.path.join(root, "/".join(keys))
         if not os.path.exists(os.path.dirname(param_file)):
             os.makedirs(os.path.dirname(param_file))
         yield leaf, param_file
@@ -80,13 +83,13 @@ def init(args):
     """
     repo = git_utils.get_git_repo()
     config_writer = repo.config_writer()
-    config_writer.set_value('filter "cml"', 'clean', 'git-cml-filter clean %f') 
-    config_writer.set_value('filter "cml"', 'smudge', 'git-cml-filter smudge %f')
-    config_writer.set_value('filter "cml"', 'required', 'true')
+    config_writer.set_value('filter "cml"', "clean", "git-cml-filter clean %f")
+    config_writer.set_value('filter "cml"', "smudge", "git-cml-filter smudge %f")
+    config_writer.set_value('filter "cml"', "required", "true")
     config_writer.release()
-    
-    with open(os.path.join(repo.working_dir, '.git/info/attributes'), 'w+') as f:
-        f.write('*.json filter=cml')
+
+    with open(os.path.join(repo.working_dir, ".git/info/attributes"), "w+") as f:
+        f.write("*.json filter=cml")
 
 
 if __name__ == "__main__":

--- a/bin/git-cml-filter
+++ b/bin/git-cml-filter
@@ -14,7 +14,8 @@ from collections import defaultdict, OrderedDict
 from git_cml import git_utils, checkpoints, params
 
 logging.basicConfig(
-    level=logging.DEBUG, format="git-cml-filter: [%(asctime)s] %(levelname)s - %(message)s"
+    level=logging.DEBUG,
+    format="git-cml-filter: [%(asctime)s] %(levelname)s - %(message)s",
 )
 
 
@@ -43,7 +44,7 @@ def clean(args):
 
     repo = git_utils.get_git_repo()
     model_dir = git_utils.create_git_cml_model_dir(repo, args.file)
-    
+
     model_checkpoint = checkpoints.JSONCheckpoint.from_file(sys.stdin)
     staged_file_contents = OrderedDict({"model_dir": model_dir})
     for param, keys in checkpoints.iterate_dict_leaves(model_checkpoint):
@@ -70,8 +71,8 @@ def smudge(args):
         d = model_dict
         for k in keys[:-1]:
             d = d[k]
-        d[keys[-1]] = git_utils.load_tracked_file(file) 
-    
+        d[keys[-1]] = git_utils.load_tracked_file(file)
+
     model_checkpoint = checkpoints.JSONCheckpoint(model_dict)
     model_checkpoint.save(sys.stdout)
 

--- a/bin/git-cml-filter
+++ b/bin/git-cml-filter
@@ -9,9 +9,9 @@ import json
 import git
 import logging
 import hashlib
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
-from git_cml import git_utils
+from git_cml import git_utils, checkpoints, params
 
 logging.basicConfig(
     level=logging.DEBUG, format="git-cml-filter: [%(asctime)s] %(levelname)s - %(message)s"
@@ -35,36 +35,6 @@ def parse_args():
     return args
 
 
-def iterate_subdirs(root, prefix=[]):
-    """
-    Generator that recursively iterates through files in a directory tree and produces (keys, value) tuples where
-    keys is the sequence of subdirectories from root to the file and value is the contents of the file.
-
-    Example
-    -------
-    root = a
-           └── b
-               ├── c
-               ├── d
-               └── e
-    iterate_subdirs(root) --> ((['a','b','c'], contents of c), (['a','b','e'], contents of e), (['a','b','d'], contents of d))
-
-    Parameters
-    ----------
-    root : str
-        Root of directory tree to iterate over
-    prefix: List[str]
-        List of keys to prefix each subdirectory sequence with
-    """
-    for d in os.listdir(root):
-        dir_member = os.path.join(root, d)
-        if os.path.isdir(dir_member):
-            yield from iterate_subdirs(dir_member, prefix=prefix + [d])
-        else:
-            contents = git_utils.load_tracked_file(dir_member)
-            yield (prefix + [d], contents)
-
-
 def clean(args):
     """
     Implements clean filter for model files
@@ -73,12 +43,16 @@ def clean(args):
 
     repo = git_utils.get_git_repo()
     model_dir = git_utils.create_git_cml_model_dir(repo, args.file)
+    
+    model_checkpoint = checkpoints.JSONCheckpoint.from_file(sys.stdin)
+    staged_file_contents = OrderedDict({"model_dir": model_dir})
+    for param, keys in checkpoints.iterate_dict_leaves(model_checkpoint):
+        param_name = "/".join(keys)
+        staged_file_contents[f"{param_name} shape"] = params.get_shape_str(param)
+        staged_file_contents[f"{param_name} dtype"] = params.get_dtype_str(param)
+        staged_file_contents[f"{param_name} hash"] = params.get_hash(param)
 
-    model = sys.stdin.buffer.read()
-    model_hash = hashlib.sha1(model).hexdigest()
-
-    pointer_file_contents = {"model_dir": model_dir, "hash": model_hash}
-    sys.stdout.buffer.write(json.dumps(pointer_file_contents).encode())
+    git_utils.write_staged_file(sys.stdout, staged_file_contents)
 
 
 def smudge(args):
@@ -88,18 +62,18 @@ def smudge(args):
     logging.debug(f"Running smudge filter on {args.file}")
 
     repo = git_utils.get_git_repo()
-    pointer_file = json.load(sys.stdin.buffer)
+    staged_file = git_utils.load_staged_file(sys.stdin)
 
     model_dict = defaultdict(dict)
-    for (keys, contents) in iterate_subdirs(pointer_file["model_dir"]):
-        logging.debug(f"Populating model parameter {keys}")
+    for file, keys in checkpoints.iterate_dir_leaves(staged_file["model_dir"]):
+        logging.debug(f"Populating model parameter {'/'.join(keys)}")
         d = model_dict
         for k in keys[:-1]:
             d = d[k]
-        d[keys[-1]] = contents
-
-    logging.debug(model_dict)
-    sys.stdout.buffer.write(json.dumps(model_dict).encode())
+        d[keys[-1]] = git_utils.load_tracked_file(file) 
+    
+    model_checkpoint = checkpoints.JSONCheckpoint(model_dict)
+    model_checkpoint.save(sys.stdout)
 
 
 if __name__ == "__main__":

--- a/git_cml/__init__.py
+++ b/git_cml/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "0.0.0"
 
-from . import checkpoints, git_utils
+from . import checkpoints, git_utils, params

--- a/git_cml/checkpoints.py
+++ b/git_cml/checkpoints.py
@@ -1,27 +1,32 @@
 """Backends for different checkpoint formats."""
 
 import torch
+import os
+import json
+import io
 
 
 class Checkpoint(dict):
     """Abstract base class for wrapping checkpoint formats."""
-
-    def __init__(self, checkpoint_path):
+    
+    @classmethod
+    def from_file(cls, checkpoint_path):
         """Create a new Checkpoint object.
 
         Parameters
         ----------
-        checkpoint_path : str
+        checkpoint_path : str or file-like object
             Path to a checkpoint file
         """
-        super(Checkpoint, self).__init__(self._load(checkpoint_path))
-
-    def _load(self, checkpoint_path):
+        return cls(cls._load(checkpoint_path))
+    
+    @classmethod
+    def _load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.
 
         Parameters
         ----------
-        checkpoint_path : str
+        checkpoint_path : str or file-like object
             Path to a checkpoint file
 
         Returns
@@ -36,21 +41,22 @@ class Checkpoint(dict):
 
         Parameters
         ----------
-        checkpoint_path : str
+        checkpoint_path : str or file-like object
             Path to write out the checkpoint file to
         """
         raise NotImplementedError
-
+    
 
 class PyTorchCheckpoint(Checkpoint):
     """Class for wrapping PyTorch checkpoints."""
-
-    def _load(self, checkpoint_path):
+    
+    @classmethod
+    def _load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.
 
         Parameters
         ----------
-        checkpoint_path : str
+        checkpoint_path : str or file-like object
             Path to a checkpoint file
 
         Returns
@@ -72,8 +78,115 @@ class PyTorchCheckpoint(Checkpoint):
 
         Parameters
         ----------
-        checkpoint_path : str
+        checkpoint_path : str or file-like object
             Path to write out the checkpoint file to
         """
         checkpoint_dict = {k: torch.as_tensor(v) for k, v in self.__dict__.items()}
         torch.save(checkpoint_dict, checkpoint_path)
+
+
+class JSONCheckpoint(Checkpoint):
+    """Class for prototyping with JSON checkpoints"""
+    
+    @classmethod
+    def _load(cls, checkpoint_path):
+        """Load a checkpoint into a dict format.
+
+        Parameters
+        ----------
+        checkpoint_path : str or file-like object
+            Path to a checkpoint file
+
+        Returns
+        -------
+        model_dict : dict
+            Dictionary mapping parameter names to parameter values
+        """
+        if isinstance(checkpoint_path, io.IOBase):
+            return json.load(checkpoint_path)
+        else:
+            with open(checkpoint_path, 'r') as f:
+                return json.load(f)
+
+    def save(self, checkpoint_path):
+        """Load a checkpoint into a dict format.
+
+        Parameters
+        ----------
+        checkpoint_path : str or file-like object
+            Path to write out the checkpoint file to
+        """
+        if isinstance(checkpoint_path, io.IOBase):
+            json.dump(self, checkpoint_path)
+        else:
+            with open(checkpoint_path, 'w') as f:
+                json.dump(self, f)
+
+
+def iterate_dict_leaves(d):
+    """
+    Generator that iterates through a dictionary and produces (leaf, keys) tuples where leaf is a dictionary leaf
+    and keys is the sequence of keys used to access leaf. Dictionary is iterated in depth-first
+    order with lexicographic ordering of keys.
+
+    Example
+    -------
+    d = {'a': {'b': {'c': 10, 'd': 20, 'e': 30}}}
+    iterate_dict_leaves(d) --> ((10, ['a','b','c']), (20, ['a','b','d']), (30, ['a','b','e']))
+
+    Parameters
+    ----------
+    d : dict
+        dictionary to iterate over
+
+    Returns
+    -------
+    generator
+        generates dict leaf, key path tuples
+    """
+    def _iterate_dict_leaves(d, prefix):
+        for k in sorted(d.keys()):
+            v = d[k]
+            if isinstance(v, dict):
+                yield from _iterate_dict_leaves(v, prefix + [k])
+            else:
+                yield (v, prefix + [k])
+
+    return _iterate_dict_leaves(d, [])
+
+
+def iterate_dir_leaves(root):
+    """
+    Generator that iterates through files in a directory tree and produces (path, dirs) tuples where
+    path is the file's path and dirs is the sequence of path components from root to the file.
+
+    Example
+    -------
+    root
+    ├── a
+    │   ├── c
+    │   └── d
+    └── b
+        └── e
+
+    iterate_dir_leaves(root) --> ((root/a/c, ['a','c']), (root/a/d, ['a','d']), (root/b/e, ['b','e']))
+
+    Parameters
+    ----------
+    root : str
+        Root of directory tree to iterate over
+
+    Returns
+    -------
+    generator
+        generates directory tree leaf, subdirectory list tuples
+    """
+    def _iterate_dir_leaves(root, prefix):
+        for d in os.listdir(root):
+            dir_member = os.path.join(root, d)
+            if os.path.isdir(dir_member):
+                yield from _iterate_dir_leaves(dir_member, prefix=prefix + [d])
+            else:
+                yield (dir_member, prefix + [d])
+
+    return _iterate_dir_leaves(root, [])

--- a/git_cml/checkpoints.py
+++ b/git_cml/checkpoints.py
@@ -8,7 +8,7 @@ import io
 
 class Checkpoint(dict):
     """Abstract base class for wrapping checkpoint formats."""
-    
+
     @classmethod
     def from_file(cls, checkpoint_path):
         """Create a new Checkpoint object.
@@ -19,7 +19,7 @@ class Checkpoint(dict):
             Path to a checkpoint file
         """
         return cls(cls._load(checkpoint_path))
-    
+
     @classmethod
     def _load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.
@@ -45,11 +45,11 @@ class Checkpoint(dict):
             Path to write out the checkpoint file to
         """
         raise NotImplementedError
-    
+
 
 class PyTorchCheckpoint(Checkpoint):
     """Class for wrapping PyTorch checkpoints."""
-    
+
     @classmethod
     def _load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.
@@ -87,7 +87,7 @@ class PyTorchCheckpoint(Checkpoint):
 
 class JSONCheckpoint(Checkpoint):
     """Class for prototyping with JSON checkpoints"""
-    
+
     @classmethod
     def _load(cls, checkpoint_path):
         """Load a checkpoint into a dict format.
@@ -105,7 +105,7 @@ class JSONCheckpoint(Checkpoint):
         if isinstance(checkpoint_path, io.IOBase):
             return json.load(checkpoint_path)
         else:
-            with open(checkpoint_path, 'r') as f:
+            with open(checkpoint_path, "r") as f:
                 return json.load(f)
 
     def save(self, checkpoint_path):
@@ -119,7 +119,7 @@ class JSONCheckpoint(Checkpoint):
         if isinstance(checkpoint_path, io.IOBase):
             json.dump(self, checkpoint_path)
         else:
-            with open(checkpoint_path, 'w') as f:
+            with open(checkpoint_path, "w") as f:
                 json.dump(self, f)
 
 
@@ -144,6 +144,7 @@ def iterate_dict_leaves(d):
     generator
         generates dict leaf, key path tuples
     """
+
     def _iterate_dict_leaves(d, prefix):
         for k in sorted(d.keys()):
             v = d[k]
@@ -181,6 +182,7 @@ def iterate_dir_leaves(root):
     generator
         generates directory tree leaf, subdirectory list tuples
     """
+
     def _iterate_dir_leaves(root, prefix):
         for d in os.listdir(root):
             dir_member = os.path.join(root, d)

--- a/git_cml/git_utils.py
+++ b/git_cml/git_utils.py
@@ -2,6 +2,7 @@ import git
 import os
 import json
 import logging
+import io
 
 
 def get_git_repo():
@@ -101,6 +102,45 @@ def write_tracked_file(f, param):
     logging.debug(f"Dumping param to {f}")
     with open(f, "w") as f:
         json.dump(param, f)
+
+
+def load_staged_file(f):
+    """
+    Load staged file
+
+    Parameters
+    ----------
+    f : str or file-like object
+        staged file to load
+
+    Returns
+    -------
+    dict
+        staged file contents
+    """
+    if isinstance(f, io.IOBase):
+        return json.load(f)
+    else:
+        with open(f, 'r') as f:
+            return json.load(f)
+
+
+def write_staged_file(f, contents):
+    """
+    Write staged file
+
+    Parameters
+    ----------
+    f : str or file-like object
+        file to write staged contents to
+    contents : dict
+        dictionary to write to staged file
+    """
+    if isinstance(f, io.IOBase):
+        json.dump(contents, f, indent=4)
+    else:
+        with open(f, 'w') as f:
+            json.dump(contents, f, indent=4)
 
 
 def add_file(f, repo):

--- a/git_cml/git_utils.py
+++ b/git_cml/git_utils.py
@@ -121,7 +121,7 @@ def load_staged_file(f):
     if isinstance(f, io.IOBase):
         return json.load(f)
     else:
-        with open(f, 'r') as f:
+        with open(f, "r") as f:
             return json.load(f)
 
 
@@ -139,7 +139,7 @@ def write_staged_file(f, contents):
     if isinstance(f, io.IOBase):
         json.dump(contents, f, indent=4)
     else:
-        with open(f, 'w') as f:
+        with open(f, "w") as f:
             json.dump(contents, f, indent=4)
 
 

--- a/git_cml/params.py
+++ b/git_cml/params.py
@@ -1,15 +1,16 @@
 import hashlib
 import torch
 
+
 def get_shape_str(p):
     """
     Parameters
     ----------
     p : list or scalar
-    
+
     Returns
     -------
-    str 
+    str
         shape of parameter
     """
     return str(torch.tensor(p).numpy().shape)
@@ -20,7 +21,7 @@ def get_dtype_str(p):
     Parameters
     ----------
     p : list or scalar
-    
+
     Returns
     -------
     str
@@ -34,7 +35,7 @@ def get_hash(p):
     Parameters
     ----------
     p : list or scalar
-    
+
     Returns
     -------
     str

--- a/git_cml/params.py
+++ b/git_cml/params.py
@@ -1,0 +1,43 @@
+import hashlib
+import torch
+
+def get_shape_str(p):
+    """
+    Parameters
+    ----------
+    p : list or scalar
+    
+    Returns
+    -------
+    str 
+        shape of parameter
+    """
+    return str(torch.tensor(p).numpy().shape)
+
+
+def get_dtype_str(p):
+    """
+    Parameters
+    ----------
+    p : list or scalar
+    
+    Returns
+    -------
+    str
+        dtype of parameter
+    """
+    return torch.tensor(p).numpy().dtype.str
+
+
+def get_hash(p):
+    """
+    Parameters
+    ----------
+    p : list or scalar
+    
+    Returns
+    -------
+    str
+        hash of parameter bytes
+    """
+    return hashlib.sha1(torch.tensor(p).numpy().tobytes()).hexdigest()


### PR DESCRIPTION
Branch for getting `git diff` to work as per #20 

# How does it work:
`git diff` does a text-based diff of two files. When using smudge and clean filters, as the git-cml prototype currently does, `git diff` is applied to the files produced by the clean filter. To make `git diff` on clean-ed files meaningful, the main change was making the clean file produce files of the following form:

```
{
    "model_dir": ".git_cml/my_model",
    "layer1/w shape": "(4)",
    "layer1/w dtype": "<f4",
    "layer1/w hash": "1053595951acfc8415dc42736649f31adf824824"
    "layer2/w shape": "(8)",
    "layer2/w dtype": "<f4",
    "layer2/w hash": "5c2301b97f9d76ea2849bbab8c91591fff391c70"
}
```

The clean-ed file contains the `model_dir` where the model's data actually lives under .git_cml so that the checkpoint can be re-generated by smudge. The clean-ed file also contains parameter metadata like shape, dtype, and hash for each parameter group. Note that although the checkpoint may have the parameter groups arbitrarily ordered, the clean filter always writes the parameter groups in lexicographic order. This makes it so that when some parameter groups are changed, `git diff` can pick up on those changes and display them properly.

# Sample Output
```
● test_repo % git diff my_model.json
git-cml-filter: [2022-10-12 13:39:43,843] DEBUG - Running clean filter on my_model.json
git-cml-filter: [2022-10-12 13:39:44,340] DEBUG - Running clean filter on my_model.json
diff --git a/my_model.json b/my_model.json
index 3660c67..96bb793 100644
--- a/my_model.json
+++ b/my_model.json
@@ -3,9 +3,9 @@
     "a shape": "()",
     "a dtype": "<f4",
     "a hash": "2b2f14931dd269f3dfe833edb58efa614709f1d7",
-    "b shape": "(3,)",
+    "b shape": "(4,)",
     "b dtype": "<f4",
-    "b hash": "1053595951acfc8415dc42736649f31adf824824",
+    "b hash": "5c2301b97f9d76ea2849bbab8c91591fff391c70",
     "c shape": "(3,)",
     "c dtype": "<i8",
     "c hash": "e2d1839ed1706f7d470d87f8c48a5584cafa5a12",
@@ -14,5 +14,5 @@
     "d/b hash": "71aa908aff1548c8c6cdecf63545261584738a25",
     "d/w shape": "(4,)",
     "d/w dtype": "<i8",
-    "d/w hash": "1074bd0a31dfaae87e1c96888a19f6589ac77cc2"
+    "d/w hash": "7058fa31243e5e2ff490e42da544f9652eeef78a"
 }
```

# What Else
There's a couple other changes mixed in to this branch. Here they are:
- Implement JSONCheckpoint subclass of Checkpoint for prototyping purposes
- Change Checkpoint class so that the constructor takes a dictionary rather than a checkpoint path. Initializing from a checkpoint path can be done with Checkpoint.from_file()
- Incorporate Checkpoint subclasses into git-cml and git-cml-filter so that we can easily move to using Pytorch/TF Checkpoints in the future
- Move code for iterating through leaves of checkpoint dictionaries and parameter groups saved on filesystem into git_cml/checkpoints.py