### PR TITLE
Fix for bug introduced in pull request #43

### DIFF
--- a/bin/git-cml
+++ b/bin/git-cml
@@ -92,6 +92,7 @@ def install(args):
     config_writer = git.GitConfigParser(
         git.config.get_config_path("global"), config_level="global", read_only=False
     )
+    config_writer.remove_option('filter "lfs"', 'process')
     config_writer.set_value('filter "cml"', "clean", "git-cml-filter clean %f")
     config_writer.set_value('filter "cml"', "smudge", "git-cml-filter smudge %f")
     config_writer.set_value('filter "cml"', "required", "true")
@@ -118,12 +119,12 @@ def track(args):
             continue
         if match.group("pattern") != args.file:
             continue
-        if not 'filter="cml"' in match.group("attributes"):
-            line += ' filter="cml"'
+        if not 'filter=cml' in match.group("attributes"):
+            line += ' filter=cml'
         pattern_found = True
 
     if not pattern_found:
-        gitattributes.append(f'{args.file} filter="cml"')
+        gitattributes.append(f'{args.file} filter=cml')
 
     git_utils.write_gitattributes(gitattributes_file, gitattributes)
     git_utils.add_file(gitattributes_file, repo)

--- a/bin/git-cml-filter
+++ b/bin/git-cml-filter
@@ -46,7 +46,7 @@ def clean(args):
     model_dir = git_utils.create_git_cml_model_dir(repo, args.file)
 
     model_checkpoint = checkpoints.PyTorchCheckpoint.from_file(sys.stdin.buffer)
-    staged_file_contents = OrderedDict({"model_dir": model_dir})
+    staged_file_contents = OrderedDict({"model_dir": os.path.relpath(model_dir, repo.working_dir)})
     for param, keys in checkpoints.iterate_dict_leaves(model_checkpoint):
         param_name = "/".join(keys)
         staged_file_contents[f"{param_name} shape"] = params.get_shape_str(param)


### PR DESCRIPTION
Missed a commit on the last pull request that introduced a bug. Fix is as follows:

- When setting up `~/.gitconfig` the previous code adds `filter="cml"` but should really add `filter=cml`
- git-lfs adds a process filter (a single process that handles smudging and cleaning over the lifetime of a long-running git command). To ensure the files get cleaned and smudged in the correct order (i.e. .git_cml/* files before the actual model checkpoint) we need to disable this and just use the standard git-lfs smudge and clean filters. This reliance on smudging and cleaning occurring in lexicographic order is a bit hacky and we should think about this more in the future. Probably fine for the prototype for now.
- The git-cml clean filter puts a `model_dir` key in a checkpoint's cleaned metadata file that points to where the actual checkpoint data is stored (e.g., .git_cml/my_model). This should be a relative path from the repo's top-level directory so that when a different user clones the repo, the absolute path to the repo is not reflected in the metadata file.